### PR TITLE
fix the goroutine accounting to prevent a race when testing that coroutines exit

### DIFF
--- a/parallel.go
+++ b/parallel.go
@@ -109,15 +109,15 @@ func NewDecompressor(ctx context.Context, opts ...DecompressorOption) *Decompres
 		go func() {
 			atomic.AddInt64(&numDecompressionGoRoutines, 1)
 			dc.worker(ctx, dc.workCh, dc.doneCh)
-			dc.workWg.Done()
 			atomic.AddInt64(&numDecompressionGoRoutines, -1)
+			dc.workWg.Done()
 		}()
 	}
 	go func() {
 		atomic.AddInt64(&numDecompressionGoRoutines, 1)
 		dc.assemble(ctx, dc.doneCh)
-		dc.doneWg.Done()
 		atomic.AddInt64(&numDecompressionGoRoutines, -1)
+		dc.doneWg.Done()
 	}()
 	return dc
 }


### PR DESCRIPTION
Moving decrement of the outstanding # of goroutines before calling waitgroup.Done() prevents a race between Finish() exiting and the rest of the goroutine finishing execution. On slow systems the goroutines appear to get de-scheduled when the waitgroup.Done() is called and hence before the goroutine count is decremented.