### PR TITLE
fix a bug in the bitstream.Scan.

### DIFF
--- a/internal/bitstream/bits.go
+++ b/internal/bitstream/bits.go
@@ -6,7 +6,6 @@ package bitstream
 import (
 	"bytes"
 	"encoding/binary"
-	"log"
 	"sync"
 
 	"github.com/cosnicolaou/pbzip2/internal/bzip2"
@@ -141,12 +140,11 @@ func Scan(first, second map[uint32]uint8, input []byte) (int, int) {
 			nv = binary.LittleEndian.Uint32(input[pos : pos+4])
 		}
 		s, ok := second[nv]
-		if !ok {
+		if !ok || s != shift {
+			// if s != shift then one or more bits occurred between the
+			// first and second match above.
 			pos = rpos + 1
 			continue
-		}
-		if s != shift {
-			log.Fatalf("internal consistency error: table indicates offset of %v, but found %v", s, shift)
 		}
 		return rpos, int(shift)
 	}

--- a/internal/bitstream/bits_test.go
+++ b/internal/bitstream/bits_test.go
@@ -347,5 +347,39 @@ func TestBitAppend(t *testing.T) {
 			break
 		}
 	}
+}
 
+func TestScanInconsistency(t *testing.T) {
+	Init()
+	buf := make([]byte, 16)
+	copy(buf[1:], bzip2.BlockMagic[:])
+	byteOffset, bitOffset := Scan(firstBlockMagicLookup, secondBlockMagicLookup, buf)
+
+	if got, want := byteOffset, 1; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := bitOffset, 0; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	ShiftRight(buf[1:])
+	byteOffset, bitOffset = Scan(firstBlockMagicLookup, secondBlockMagicLookup, buf)
+	if got, want := byteOffset, 1; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := bitOffset, 1; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	buf = make([]byte, 16)
+	copy(buf[1:], bzip2.BlockMagic[:])
+	ShiftRight(buf[5:])
+
+	byteOffset, bitOffset = Scan(firstBlockMagicLookup, secondBlockMagicLookup, buf)
+	if got, want := byteOffset, -1; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := bitOffset, -1; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
 }

--- a/internal/bitstream/bits_test.go
+++ b/internal/bitstream/bits_test.go
@@ -362,24 +362,35 @@ func TestScanInconsistency(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	ShiftRight(buf[1:])
-	byteOffset, bitOffset = Scan(firstBlockMagicLookup, secondBlockMagicLookup, buf)
-	if got, want := byteOffset, 1; got != want {
-		t.Errorf("got %v, want %v", got, want)
-	}
-	if got, want := bitOffset, 1; got != want {
-		t.Errorf("got %v, want %v", got, want)
+	// Insert one or more bits between the first 4 and last 2 bytes of the
+	// magic number.
+	for i := 1; i <= 8; i++ {
+		buf = make([]byte, 16)
+		copy(buf[1:], bzip2.BlockMagic[:])
+		for s := 0; s < i; s++ {
+			ShiftRight(buf[5:])
+		}
+
+		byteOffset, bitOffset = Scan(firstBlockMagicLookup, secondBlockMagicLookup, buf)
+		if got, want := byteOffset, -1; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
+		if got, want := bitOffset, -1; got != want {
+			t.Errorf("got %v, want %v", got, want)
+		}
 	}
 
-	buf = make([]byte, 16)
+	buf = make([]byte, 30)
 	copy(buf[1:], bzip2.BlockMagic[:])
+	copy(buf[20:], bzip2.BlockMagic[:])
+	ShiftRight(buf[20:])
 	ShiftRight(buf[5:])
-
 	byteOffset, bitOffset = Scan(firstBlockMagicLookup, secondBlockMagicLookup, buf)
-	if got, want := byteOffset, -1; got != want {
+	if got, want := byteOffset, 20; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
-	if got, want := bitOffset, -1; got != want {
+	if got, want := bitOffset, 2; got != want {
 		t.Errorf("got %v, want %v", got, want)
 	}
+
 }


### PR DESCRIPTION
As pointed out by #13 he bitstream scanner would call log.Fatal if it detected a 'gap' between the a match on the first 4 bytes of the magic # and the last 6 bytes. This PR addresses this by correctly catching this case as a failure to match the magic #. See TestScanInconsistency for how to repro this case.  

