### PR TITLE
Do not send progress anymore if context has been canceled

### DIFF
--- a/parallel.go
+++ b/parallel.go
@@ -359,7 +359,7 @@ func (dc *Decompressor) assemble(ctx context.Context, ch <-chan *blockDesc) {
 					dc.streamCRC = 0
 				}
 
-				if dc.progressCh != nil {
+				if dc.progressCh != nil && ctx.Err() == nil {
 					dc.progressCh <- Progress{
 						Duration:   min.duration,
 						Block:      min.order,


### PR DESCRIPTION
When context is canceled, the `progressCh` channel might already be closed.