### PR TITLE
reduce complexity of Decompressor.assemble

### DIFF
--- a/parallel.go
+++ b/parallel.go
@@ -320,6 +320,7 @@ func (dc *Decompressor) tryMergeBlocks(ctx context.Context, ch <-chan *blockDesc
 }
 
 func (dc *Decompressor) handlePossibleEOS(min *blockDesc) error {
+	dc.streamCRC = updateStreamCRC(dc.streamCRC, min.CRC)
 	if min.EOS {
 		if got, want := dc.streamCRC, min.StreamCRC; got != want {
 			return fmt.Errorf("mismatched stream CRCs: calculated=0x%08x != stored=0x%08x", got, want)
@@ -359,7 +360,6 @@ func (dc *Decompressor) assemble(ctx context.Context, ch <-chan *blockDesc) {
 					dc.pwr.CloseWithError(err)
 					return
 				}
-				dc.streamCRC = updateStreamCRC(dc.streamCRC, min.CRC)
 				if err := dc.handlePossibleEOS(min); err != nil {
 					dc.pwr.CloseWithError(err)
 					return

--- a/parallel.go
+++ b/parallel.go
@@ -320,13 +320,12 @@ func (dc *Decompressor) tryMergeBlocks(ctx context.Context, ch <-chan *blockDesc
 }
 
 func (dc *Decompressor) handlePossibleEOS(min *blockDesc) error {
-	if !min.EOS {
-		return nil
+	if min.EOS {
+		if got, want := dc.streamCRC, min.StreamCRC; got != want {
+			return fmt.Errorf("mismatched stream CRCs: calculated=0x%08x != stored=0x%08x", got, want)
+		}
+		dc.streamCRC = 0
 	}
-	if got, want := dc.streamCRC, min.StreamCRC; got != want {
-		return fmt.Errorf("mismatched stream CRCs: calculated=0x%08x != stored=0x%08x", got, want)
-	}
-	dc.streamCRC = 0
 	return nil
 }
 

--- a/parallel.go
+++ b/parallel.go
@@ -319,8 +319,18 @@ func (dc *Decompressor) tryMergeBlocks(ctx context.Context, ch <-chan *blockDesc
 
 }
 
+func (dc *Decompressor) handlePossibleEOS(min *blockDesc) error {
+	if !min.EOS {
+		return nil
+	}
+	if got, want := dc.streamCRC, min.StreamCRC; got != want {
+		return fmt.Errorf("mismatched stream CRCs: calculated=0x%08x != stored=0x%08x", got, want)
+	}
+	dc.streamCRC = 0
+	return nil
+}
+
 func (dc *Decompressor) assemble(ctx context.Context, ch <-chan *blockDesc) {
-	defer dc.pwr.Close()
 	expected := uint64(1)
 	for {
 		dc.trace("assemble select")
@@ -351,14 +361,10 @@ func (dc *Decompressor) assemble(ctx context.Context, ch <-chan *blockDesc) {
 					return
 				}
 				dc.streamCRC = updateStreamCRC(dc.streamCRC, min.CRC)
-				if min.EOS {
-					if got, want := dc.streamCRC, min.StreamCRC; got != want {
-						dc.pwr.CloseWithError(fmt.Errorf("mismatched stream CRCs: calculated=0x%08x != stored=0x%08x", got, want))
-						return
-					}
-					dc.streamCRC = 0
+				if err := dc.handlePossibleEOS(min); err != nil {
+					dc.pwr.CloseWithError(err)
+					return
 				}
-
 				if dc.progressCh != nil && ctx.Err() == nil {
 					dc.progressCh <- Progress{
 						Duration:   min.duration,
@@ -370,6 +376,7 @@ func (dc *Decompressor) assemble(ctx context.Context, ch <-chan *blockDesc) {
 				}
 			}
 			if block == nil && len(*dc.heap) == 0 {
+				dc.pwr.Close()
 				return
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
Avoid spurious call to dc.pwr.Close() via defer when an error occurs dc.pwr.CloseWithError(err) is called anyway. There is only one non-error return in any case. Reduce the complexity of the assemble function to keep the gocyclo lint check metric to under 15.