### PR TITLE
fix for #33

### DIFF
--- a/parallel.go
+++ b/parallel.go
@@ -310,12 +310,12 @@ func (dc *Decompressor) tryMergeBlocks(ctx context.Context, ch <-chan *blockDesc
 		// check to see if the channel has been closed, failing to do
 		// so can lead to hangs since the next block may not exist in
 		// a corrupted input file.
-		select {
-		case block, ok := <-ch:
-			if !ok {
-				// channel has been closed.
-				return false
-			}
+
+		block, ok := <-ch
+		if !ok {
+			// channel has been closed.
+			return false
+		} else {
 			heap.Push(dc.heap, block)
 		}
 	}

--- a/parallel.go
+++ b/parallel.go
@@ -284,6 +284,7 @@ func (h *blockHeap) Pop() interface{} {
 func (dc *Decompressor) tryMergeBlocks(ctx context.Context, ch <-chan *blockDesc, min *blockDesc) bool {
 	// wait for the second consecutive block.
 	for {
+		// wait for a new block if there none currently in the heap.
 		for len(*dc.heap) < 1 {
 			select {
 			case block, ok := <-ch:
@@ -299,10 +300,26 @@ func (dc *Decompressor) tryMergeBlocks(ctx context.Context, ch <-chan *blockDesc
 				return false
 			}
 		}
+
 		if (*dc.heap)[0].order == min.order+1 {
+			// successfully found the next block that can be merged
+			// with the current one.
 			break
 		}
+
+		// check to see if the channel has been closed, failing to do
+		// so can lead to hangs since the next block may not exist in
+		// a corrupted input file.
+		select {
+		case block, ok := <-ch:
+			if !ok {
+				// channel has been closed.
+				return false
+			}
+			heap.Push(dc.heap, block)
+		}
 	}
+
 	next := (*dc.heap)[0]
 	bwr := &bitstream.BitWriter{}
 	// Note that the first block has an offset in the first byte and a size in


### PR DESCRIPTION
Issue #33 reports a hang when processing a corrupted input file. The hang is due to the logic in tryMergeBlocks that wait indefinitely for the 'next block' even one does not exist and the input stream has been completely processed. This occurs because there is not test for the input channel being closed unless the heap of decompressed blocks is empty. The fix is simply to check for the channel being closed even when the heap is not empty.