### PR TITLE
perf: Optimize readBlock function for large inputs

### DIFF
--- a/bzip2_testsuite_test.go
+++ b/bzip2_testsuite_test.go
@@ -97,7 +97,7 @@ func TestBzip2Tests(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, tc := range testcases {
-		t.Logf(tc.filename)
+		t.Log(tc.filename)
 		bzfile, err := os.Open(tc.filename)
 		if err != nil {
 			t.Errorf("%v: %v", tc.filename, err)

--- a/internal/bzip2/bzip2.go
+++ b/internal/bzip2/bzip2.go
@@ -447,11 +447,13 @@ func (bz2 *reader) readBlock() (err error) {
 			if repeat > bz2.blockSize-bufIndex {
 				return StructuralError("repeats past end of block")
 			}
-			for i := 0; i < repeat; i++ {
-				b := mtf.First()
-				bz2.tt[bufIndex] = uint32(b)
-				bz2.c[b]++
-				bufIndex++
+			c := bz2.c[:]
+			tt := bz2.tt[bufIndex : bufIndex+repeat]
+			bufIndex += repeat
+			b := mtf.First()
+			c[b] += uint(repeat)
+			for i := range tt {
+				tt[i] = uint32(b)
 			}
 			repeat = 0
 		}


### PR DESCRIPTION
Improved performance of readBlock function when processing large dumps like enwiktionary-latest-pages-articles.xml.bz2 (1.3GB compressed, 9.8GB uncompressed), achieving 5% speedup.

Test data:
- Source: dumps.wikimedia.org/enwiktionary/latest/
- File: enwiktionary-latest-pages-articles.xml.bz2

Benchmark results:
Before:
```
goos: darwin
goarch: arm64
pkg: github.com/cosnicolaou/pbzip2/internal/bzip2
cpu: Apple M2 Max
BenchmarkDecodeDigits-12    	     328	   3680897 ns/op	  27.17 MB/s	 3612909 B/op	      51 allocs/op
BenchmarkDecodeDigits-12    	     328	   3624393 ns/op	  27.59 MB/s	 3612919 B/op	      51 allocs/op
BenchmarkDecodeDigits-12    	     328	   3637397 ns/op	  27.49 MB/s	 3612934 B/op	      51 allocs/op
BenchmarkDecodeNewton-12    	      79	  14678359 ns/op	  38.64 MB/s	 3630748 B/op	      51 allocs/op
BenchmarkDecodeNewton-12    	      79	  14690602 ns/op	  38.61 MB/s	 3630749 B/op	      51 allocs/op
BenchmarkDecodeNewton-12    	      80	  14581105 ns/op	  38.90 MB/s	 3630767 B/op	      51 allocs/op
BenchmarkDecodeRand-12      	     972	   1243251 ns/op	  13.18 MB/s	 3644077 B/op	      51 allocs/op
BenchmarkDecodeRand-12      	     966	   1249473 ns/op	  13.11 MB/s	 3644078 B/op	      51 allocs/op
BenchmarkDecodeRand-12      	     960	   1244365 ns/op	  13.17 MB/s	 3644077 B/op	      51 allocs/op
BenchmarkWiktionary-12      	       1	213761204000 ns/op	  49.12 MB/s	367216760 B/op	  542483 allocs/op
BenchmarkWiktionary-12      	       1	214464191333 ns/op	  48.96 MB/s	367216776 B/op	  542483 allocs/op
BenchmarkWiktionary-12      	       1	212462041000 ns/op	  49.42 MB/s	367216776 B/op	  542483 allocs/op
```

After:
```
goos: darwin
goarch: arm64
pkg: github.com/cosnicolaou/pbzip2/internal/bzip2
cpu: Apple M2 Max
BenchmarkDecodeDigits-12    	     327	   3616069 ns/op	  27.66 MB/s	 3612908 B/op	      51 allocs/op
BenchmarkDecodeDigits-12    	     331	   3636687 ns/op	  27.50 MB/s	 3612913 B/op	      51 allocs/op
BenchmarkDecodeDigits-12    	     330	   3643335 ns/op	  27.45 MB/s	 3612933 B/op	      51 allocs/op
BenchmarkDecodeNewton-12    	      81	  14595539 ns/op	  38.86 MB/s	 3630747 B/op	      51 allocs/op
BenchmarkDecodeNewton-12    	      80	  14457038 ns/op	  39.23 MB/s	 3630764 B/op	      51 allocs/op
BenchmarkDecodeNewton-12    	      81	  14434380 ns/op	  39.29 MB/s	 3630760 B/op	      51 allocs/op
BenchmarkDecodeRand-12      	     948	   1241605 ns/op	  13.20 MB/s	 3644075 B/op	      51 allocs/op
BenchmarkDecodeRand-12      	     958	   1243511 ns/op	  13.18 MB/s	 3644077 B/op	      51 allocs/op
BenchmarkDecodeRand-12      	     972	   1251828 ns/op	  13.09 MB/s	 3644077 B/op	      51 allocs/op
BenchmarkWiktionary-12      	       1	200375315042 ns/op	  52.40 MB/s	367216760 B/op	  542483 allocs/op
BenchmarkWiktionary-12      	       1	204808798292 ns/op	  51.26 MB/s	367216760 B/op	  542483 allocs/op
BenchmarkWiktionary-12      	       1	208077592833 ns/op	  50.46 MB/s	367216776 B/op	  542483 allocs/op
```